### PR TITLE
adding template literals and spanning info box elements

### DIFF
--- a/Assets/css/style.css
+++ b/Assets/css/style.css
@@ -15,3 +15,32 @@
 #footer {
     height: 200px;
 }
+
+#showName {
+    font-size: 25px;
+    font-weight: bold;
+}
+
+#showNameCategory {
+    font-weight: bold;
+}
+
+#genres {
+    font-weight: bold;
+}
+
+#premiered {
+    font-weight: bold;
+}
+
+#status {
+    font-weight: bold;
+}
+
+#rating {
+    font-weight: bold;
+}
+
+#summary {
+    font-weight: bold;
+}

--- a/Assets/js/script.js
+++ b/Assets/js/script.js
@@ -1,13 +1,15 @@
 const renderData = function (dataToBeRendered) {
     $("#mainContainer").empty(); // empties the container before appending data
     // generate title dynamically
-    var nameEl = $("<h3>").text(dataToBeRendered.name);
+    // applying template literals to create a mix of static category names and dynamically updated search results
+    // spanning the category names to apply special styles to them + spanning the "showName" for bigger font
+    var nameEl = $("<p>").html(`<span id="showNameCategory">Show name:</span> <span id="showName">${dataToBeRendered.name}</span>`);
     nameEl.attr("class", "title") //just a test
-    var genresEl = $("<p>").text(dataToBeRendered.genres.join(", ")); // because this element has multiple results (genres)
-    var premieredEl = $("<p>").text(dataToBeRendered.premiered);
-    var statusEl = $("<p>").text(dataToBeRendered.status);
-    var ratingEl = $("<p>").text(dataToBeRendered.rating);
-    var summaryEl = $("<p>").html(dataToBeRendered.summary);
+    var genresEl = $("<p>").html(`<span id="genres">Genre(s):</span> ${dataToBeRendered.genres.join(", ")}`); // because this element has multiple results (genres)
+    var premieredEl = $("<p>").html(`<span id="premiered">Premiered (Y/M/D):</span> ${dataToBeRendered.premiered}`);
+    var statusEl = $("<p>").html(`<span id="status">Status:</span> ${dataToBeRendered.status}`);
+    var ratingEl = $("<p>").html(`<span id="rating">Rating (out of 10):</span> ${dataToBeRendered.rating}`);
+    var summaryEl = $("<p>").html(`<span id="summary">Summary: </span>${dataToBeRendered.summary}`);
     $("#mainContainer").append(nameEl)
     $("#mainContainer").append(genresEl)
     $("#mainContainer").append(premieredEl)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+This is a:
+​
+- [ ] :sparkles: **New feature** - new behaviour has been implemented
+- [ ] :bug: **Bug fix** - existing behaviour has been made to behave
+- [ ] :recycle: **Refactor** - the behaviour has not changed, just the implementation
+- [ ] :white_check_mark: **Test backfill** - tests for existing behaviour were added but the behaviour itself hasn't changed
+- [ ] :gear: **Chore** - maintenance task, behaviour and implementation haven't changed
+​
+### Description
+​
+- **Purpose** - Short description of the pull request
+- **How to check** -
+  - Step 1
+  - Step 2
+​
+### Links
+​
+- **Issue**: [Link to the issue](https://github.com/tornicke/field-potato/issues)
+​
+### Reminder to reviewers
+​
+- **Pull request** - read the content of the PR itself (_Conversation_ tab) and consider the following questions:
+​
+  - Is the user story/ticket linked?
+  - Does the description match the linked item?
+  - Does the description tell you how to validate the work?
+  - Does the build still work (_Checks_ tab)?
+  - What approach would you take to meet this goal?
+​
+- **Code changes** - read through the changeset (_Files changed_ tab) and consider the following questions:
+​
+  - Do the code changes match the description?
+  - Are there any changes that should not be part of this pull request (e.g. layout changes in files not related to the functionality)?
+  - Do you understand what the changes are doing, how they meet the goal of the PR?
+  - Does the approach to meeting those goals seem sensible? If it's not the one you thought of, is it significantly better or worse?
+  - Is this well-structured code (consistent layout, comprehensible variable names, relatively small files)?
+​
+- **Software** - check out the PR branch, run the software and consider the following questions:
+​
+  - Does the product still start and run correctly?
+  - Is the goal of the pull request met (i.e. new behaviour for a new feature, changed behaviour for a bug fix, identical behaviour for a refactor)?
+  - In the parts of the product this PR touched:
+​
+    - Is the spelling, punctuation and grammar for user-facing text correct?
+    - Does the layout/UI match the designs?

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <nav>
       <!--Adding nav bar items using Blaze UI, centered and hyperlinked to relevant sections-->
         <ul class="c-list c-list--inline" style="text-align: center;">
-          <li class="c-list__item"><a href="#header/"><u>home</u></a></li>
+          <li class="c-list__item"><a href="#header"><u>home</u></a></li>
           <li class="c-list__item"><a href="#mainContainer"><u>my list</u></a></li>
           <li class="c-list__item"><a href="#footer"><u>contact</u></a></li>
         </ul>


### PR DESCRIPTION
This is a:
​
- [x] :sparkles: **New feature** - new behaviour has been implemented
- [ ] :bug: **Bug fix** - existing behaviour has been made to behave
- [ ] :recycle: **Refactor** - the behaviour has not changed, just the implementation
- [ ] :white_check_mark: **Test backfill** - tests for existing behaviour were added but the behaviour itself hasn't changed
- [ ] :gear: **Chore** - maintenance task, behaviour and implementation haven't changed
​
### Description
​
- **Purpose** - Added show category names to the info box, added CSS styles, removed a typo from a navbar link
- **How to check** -
  - Step 1: Run index.html in your browser
  - Step 2: Search for a show
  - Step 3: Make sure that show information comes up with category names (e.g. **Show name**: Homeland)

### Links

- **Issue**:  No issue created yet
